### PR TITLE
Strengthen specs

### DIFF
--- a/tasks/human_eval_008.rs
+++ b/tasks/human_eval_008.rs
@@ -39,10 +39,13 @@ fn sum_product(numbers: Vec<u32>) -> (result: (u64, Option<u32>))
     ensures
         result.0 == sum(numbers@),
         match result.1 {
-            None => // Computing the product overflowed at some point
-                exists |i| #![auto] 0 <= i < numbers.len() && product(numbers@.subrange(0, i)) * numbers[i] as int > u32::MAX,
+            None =>   // Computing the product overflowed at some point
+            exists|i|
+                #![auto]
+                0 <= i < numbers.len() && product(numbers@.subrange(0, i)) * numbers[i] as int
+                    > u32::MAX,
             Some(v) => v == product(numbers@),
-        }
+        },
 {
     let mut sum_value: u64 = 0;
     let mut prod_value: Option<u32> = Some(1);
@@ -52,8 +55,11 @@ fn sum_product(numbers: Vec<u32>) -> (result: (u64, Option<u32>))
             sum_value == sum(numbers@.take(index as int)),
             prod_value matches Some(v) ==> v == product(numbers@.take(index as int)),
             match prod_value {
-                None => // Computing the product overflowed at some point
-                    exists |i| #![auto] 0 <= i < index && product(numbers@.subrange(0, i)) * numbers[i] as int > u32::MAX,
+                None =>   // Computing the product overflowed at some point
+                exists|i|
+                    #![auto]
+                    0 <= i < index && product(numbers@.subrange(0, i)) * numbers[i] as int
+                        > u32::MAX,
                 Some(v) => v == product(numbers@.take(index as int)),
             },
             index <= numbers.len(),

--- a/tasks/human_eval_008.rs
+++ b/tasks/human_eval_008.rs
@@ -38,7 +38,11 @@ fn sum_product(numbers: Vec<u32>) -> (result: (u64, Option<u32>))
         numbers.len() < u32::MAX,
     ensures
         result.0 == sum(numbers@),
-        result.1 matches Some(v) ==> v == product(numbers@),
+        match result.1 {
+            None => // Computing the product overflowed at some point
+                exists |i| #![auto] 0 <= i < numbers.len() && product(numbers@.subrange(0, i)) * numbers[i] as int > u32::MAX,
+            Some(v) => v == product(numbers@),
+        }
 {
     let mut sum_value: u64 = 0;
     let mut prod_value: Option<u32> = Some(1);
@@ -47,6 +51,11 @@ fn sum_product(numbers: Vec<u32>) -> (result: (u64, Option<u32>))
             numbers.len() < u32::MAX,
             sum_value == sum(numbers@.take(index as int)),
             prod_value matches Some(v) ==> v == product(numbers@.take(index as int)),
+            match prod_value {
+                None => // Computing the product overflowed at some point
+                    exists |i| #![auto] 0 <= i < index && product(numbers@.subrange(0, i)) * numbers[i] as int > u32::MAX,
+                Some(v) => v == product(numbers@.take(index as int)),
+            },
             index <= numbers.len(),
             index >= 0,
     {

--- a/tasks/human_eval_055a.rs
+++ b/tasks/human_eval_055a.rs
@@ -22,9 +22,9 @@ spec fn spec_fib(n: nat) -> nat
     }
 }
 
-proof fn lemma_fib_monotonic(i:nat, j:nat)
+proof fn lemma_fib_monotonic(i: nat, j: nat)
     requires
-        i <= j
+        i <= j,
     ensures
         spec_fib(i) <= spec_fib(j),
     decreases j - i,
@@ -43,7 +43,7 @@ fn fib(n: u32) -> (ret: Option<u32>)
     ensures
         match ret {
             None => spec_fib(n as nat) > u32::MAX,
-            Some(f) => f == spec_fib(n as nat)
+            Some(f) => f == spec_fib(n as nat),
         },
 {
     if n > 47 {

--- a/tasks/human_eval_055b.rs
+++ b/tasks/human_eval_055b.rs
@@ -10,6 +10,8 @@ use vstd::prelude::*;
 verus! {
 
 // O(n) non-recursive solution using same spec as 55a
+
+#[verifier::memoize]
 spec fn spec_fib(n: nat) -> nat
     decreases n,
 {
@@ -22,9 +24,29 @@ spec fn spec_fib(n: nat) -> nat
     }
 }
 
+proof fn lemma_fib_monotonic(i:nat, j:nat)
+    requires
+        i <= j
+    ensures
+        spec_fib(i) <= spec_fib(j),
+    decreases j - i,
+{
+    if (i < 2 && j < 2) || i == j {
+    } else if i == j - 1 {
+        reveal_with_fuel(spec_fib, 2);
+        lemma_fib_monotonic(i, (j - 1) as nat);
+    } else {
+        lemma_fib_monotonic(i, (j - 1) as nat);
+        lemma_fib_monotonic(i, (j - 2) as nat);
+    }
+}
+
 fn fib(n: u32) -> (ret: Option<u32>)
     ensures
-        ret.is_some() ==> ret.unwrap() == spec_fib(n as nat),
+        match ret {
+            None => spec_fib(n as nat) > u32::MAX,
+            Some(f) => f == spec_fib(n as nat)
+        },
 {
     if n == 0 {
         return Some(0);
@@ -32,17 +54,31 @@ fn fib(n: u32) -> (ret: Option<u32>)
     if n == 1 {
         return Some(1);
     }
+    if n > 47 {
+        proof {
+            assert(spec_fib(48) > u32::MAX) by (compute_only);
+            lemma_fib_monotonic(48, n as nat);
+        }
+        return None;
+    }
     let mut a: u32 = 0;
     let mut b: u32 = 1;
     let mut i: u32 = 2;
 
     for i in 1..n
         invariant
-            1 <= i as int <= n,
+            1 <= i as int <= n <= 47,
             a as int == spec_fib((i - 1) as nat),
             b as int == spec_fib(i as nat),
     {
-        let sum = a.checked_add(b)?;
+        proof {
+            // Prove that that n1 + n2 won't overflow
+            assert(spec_fib(47) < u32::MAX) by (compute_only);
+            lemma_fib_monotonic(i as nat, 47);
+            lemma_fib_monotonic((i - 1) as nat, 47);
+            lemma_fib_monotonic((i + 1) as nat, 47);
+        }
+        let sum = a + b;
         a = b;
         b = sum;
     }

--- a/tasks/human_eval_055b.rs
+++ b/tasks/human_eval_055b.rs
@@ -10,7 +10,6 @@ use vstd::prelude::*;
 verus! {
 
 // O(n) non-recursive solution using same spec as 55a
-
 #[verifier::memoize]
 spec fn spec_fib(n: nat) -> nat
     decreases n,
@@ -24,9 +23,9 @@ spec fn spec_fib(n: nat) -> nat
     }
 }
 
-proof fn lemma_fib_monotonic(i:nat, j:nat)
+proof fn lemma_fib_monotonic(i: nat, j: nat)
     requires
-        i <= j
+        i <= j,
     ensures
         spec_fib(i) <= spec_fib(j),
     decreases j - i,
@@ -45,7 +44,7 @@ fn fib(n: u32) -> (ret: Option<u32>)
     ensures
         match ret {
             None => spec_fib(n as nat) > u32::MAX,
-            Some(f) => f == spec_fib(n as nat)
+            Some(f) => f == spec_fib(n as nat),
         },
 {
     if n == 0 {

--- a/tasks/human_eval_059.rs
+++ b/tasks/human_eval_059.rs
@@ -46,7 +46,7 @@ fn largest_prime_factor(n: u32) -> (largest: u32)
         1 <= largest <= n,
         spec_prime(largest as int),
         n % largest == 0,
-        forall |p| 0 <= p < n && spec_prime(p) && n as int % p == 0 ==> p <= largest,
+        forall|p| 0 <= p < n && spec_prime(p) && n as int % p == 0 ==> p <= largest,
 {
     let mut largest = 1;
     let mut j = 1;
@@ -55,7 +55,7 @@ fn largest_prime_factor(n: u32) -> (largest: u32)
             1 <= largest <= j <= n,
             spec_prime(largest as int),
             n % largest == 0,
-            forall |p| 0 <= p <= j && spec_prime(p) && n as int % p == 0 ==> p <= largest,
+            forall|p| 0 <= p <= j && spec_prime(p) && n as int % p == 0 ==> p <= largest,
     {
         j += 1;
         let flag = is_prime(j);

--- a/tasks/human_eval_059.rs
+++ b/tasks/human_eval_059.rs
@@ -45,6 +45,8 @@ fn largest_prime_factor(n: u32) -> (largest: u32)
     ensures
         1 <= largest <= n,
         spec_prime(largest as int),
+        n % largest == 0,
+        forall |p| 0 <= p < n && spec_prime(p) && n as int % p == 0 ==> p <= largest,
 {
     let mut largest = 1;
     let mut j = 1;
@@ -52,6 +54,8 @@ fn largest_prime_factor(n: u32) -> (largest: u32)
         invariant
             1 <= largest <= j <= n,
             spec_prime(largest as int),
+            n % largest == 0,
+            forall |p| 0 <= p <= j && spec_prime(p) && n as int % p == 0 ==> p <= largest,
     {
         j += 1;
         let flag = is_prime(j);

--- a/tasks/human_eval_060.rs
+++ b/tasks/human_eval_060.rs
@@ -19,9 +19,9 @@ spec fn spec_sum_to_n(n: nat) -> nat
     }
 }
 
-proof fn lemma_sum_monotonic(i:nat, j:nat)
+proof fn lemma_sum_monotonic(i: nat, j: nat)
     requires
-        i <= j
+        i <= j,
     ensures
         spec_sum_to_n(i) <= spec_sum_to_n(j),
     decreases j - i,
@@ -38,7 +38,7 @@ fn sum_to_n(n: u32) -> (sum: Option<u32>)
     ensures
         match sum {
             None => spec_sum_to_n(n as nat) > u32::MAX,
-            Some(f) => f == spec_sum_to_n(n as nat)
+            Some(f) => f == spec_sum_to_n(n as nat),
         },
 {
     if n >= 92682 {

--- a/tasks/human_eval_062.rs
+++ b/tasks/human_eval_062.rs
@@ -9,22 +9,35 @@ use vstd::prelude::*;
 
 verus! {
 
-fn derivative(xs: &Vec<usize>) -> (ret: Option<Vec<usize>>)
+fn derivative(xs: &Vec<u32>) -> (ret: Vec<u64>)
+    requires
+        xs.len() <= u32::MAX,
     ensures
-        ret.is_some() ==> xs@.len() == 0 || xs@.map(|i: int, x| i * x).skip(1)
-            =~= ret.unwrap()@.map_values(|x| x as int),
+        if xs.len() == 0 {
+            ret.len() == 0 
+        } else {
+            ret@.map_values(|x| x as int) 
+            =~= 
+            xs@.map(|i: int, x| i * x).skip(1)
+        }
 {
     let mut ret = Vec::new();
     if xs.len() == 0 {
-        return Some(ret);
+        return ret;
     }
     let mut i = 1;
     while i < xs.len()
         invariant
             xs@.map(|i: int, x| i * x).subrange(1, i as int) =~= ret@.map_values(|x| x as int),
-            1 <= i <= xs.len(),
+            1 <= i <= xs.len() <= u32::MAX,
     {
-        ret.push(xs[i].checked_mul(i)?);
+        proof {
+            // Prove that the multiplication does not overflow
+            vstd::arithmetic::mul::lemma_mul_upper_bound(xs[i as int] as int, u32::MAX as int, i as int, u32::MAX as int);
+            assert(u32::MAX * u32::MAX <= u64::MAX);
+            assert((i as u64) * (xs[i as int] as u64) == i as int * xs[i as int]);
+        }
+        ret.push((i as u64) * (xs[i] as u64));
 
         let ghost prods = xs@.map(|i: int, x| i * x);
         assert(prods.subrange(1, i as int).push(prods.index(i as int)) =~= prods.subrange(
@@ -35,7 +48,7 @@ fn derivative(xs: &Vec<usize>) -> (ret: Option<Vec<usize>>)
         i += 1;
     }
     assert(xs@.map(|i: int, x| i * x).subrange(1, i as int) =~= xs@.map(|i: int, x| i * x).skip(1));
-    Some(ret)
+    ret
 }
 
 } // verus!

--- a/tasks/human_eval_062.rs
+++ b/tasks/human_eval_062.rs
@@ -14,12 +14,10 @@ fn derivative(xs: &Vec<u32>) -> (ret: Vec<u64>)
         xs.len() <= u32::MAX,
     ensures
         if xs.len() == 0 {
-            ret.len() == 0 
+            ret.len() == 0
         } else {
-            ret@.map_values(|x| x as int) 
-            =~= 
-            xs@.map(|i: int, x| i * x).skip(1)
-        }
+            ret@.map_values(|x| x as int) =~= xs@.map(|i: int, x| i * x).skip(1)
+        },
 {
     let mut ret = Vec::new();
     if xs.len() == 0 {
@@ -33,7 +31,12 @@ fn derivative(xs: &Vec<u32>) -> (ret: Vec<u64>)
     {
         proof {
             // Prove that the multiplication does not overflow
-            vstd::arithmetic::mul::lemma_mul_upper_bound(xs[i as int] as int, u32::MAX as int, i as int, u32::MAX as int);
+            vstd::arithmetic::mul::lemma_mul_upper_bound(
+                xs[i as int] as int,
+                u32::MAX as int,
+                i as int,
+                u32::MAX as int,
+            );
             assert(u32::MAX * u32::MAX <= u64::MAX);
             assert((i as u64) * (xs[i as int] as u64) == i as int * xs[i as int]);
         }

--- a/tasks/human_eval_063.rs
+++ b/tasks/human_eval_063.rs
@@ -24,9 +24,9 @@ spec fn spec_fibfib(n: nat) -> nat
     }
 }
 
-proof fn lemma_fibfib_monotonic(i:nat, j:nat)
+proof fn lemma_fibfib_monotonic(i: nat, j: nat)
     requires
-        i <= j
+        i <= j,
     ensures
         spec_fibfib(i) <= spec_fibfib(j),
     decreases j - i,
@@ -50,7 +50,7 @@ fn fibfib(x: u32) -> (ret: Option<u32>)
     ensures
         match ret {
             None => spec_fibfib(x as nat) > u32::MAX,
-            Some(f) => f == spec_fibfib(x as nat)
+            Some(f) => f == spec_fibfib(x as nat),
         },
 {
     if x > 39 {
@@ -75,7 +75,7 @@ fn fibfib(x: u32) -> (ret: Option<u32>)
                 lemma_fibfib_monotonic((x - 3) as nat, 39);
             }
             Some(fibfib(x - 1)? + fibfib(x - 2)? + fibfib(x - 3)?)
-        }
+        },
     }
 }
 

--- a/tasks/human_eval_063.rs
+++ b/tasks/human_eval_063.rs
@@ -9,6 +9,7 @@ use vstd::prelude::*;
 
 verus! {
 
+#[verifier::memoize]
 spec fn spec_fibfib(n: nat) -> nat
     decreases n,
 {
@@ -23,15 +24,58 @@ spec fn spec_fibfib(n: nat) -> nat
     }
 }
 
+proof fn lemma_fibfib_monotonic(i:nat, j:nat)
+    requires
+        i <= j
+    ensures
+        spec_fibfib(i) <= spec_fibfib(j),
+    decreases j - i,
+{
+    if (i < 3 && j < 3) || i == j {
+    } else if i == j - 1 {
+        reveal_with_fuel(spec_fibfib, 3);
+        lemma_fibfib_monotonic(i, (j - 1) as nat);
+    } else if i == j - 2 {
+        reveal_with_fuel(spec_fibfib, 3);
+        lemma_fibfib_monotonic(i, (j - 1) as nat);
+        lemma_fibfib_monotonic(i, (j - 2) as nat);
+    } else {
+        lemma_fibfib_monotonic(i, (j - 1) as nat);
+        lemma_fibfib_monotonic(i, (j - 2) as nat);
+        lemma_fibfib_monotonic(i, (j - 3) as nat);
+    }
+}
+
 fn fibfib(x: u32) -> (ret: Option<u32>)
     ensures
-        ret.is_some() ==> spec_fibfib(x as nat) == ret.unwrap(),
+        match ret {
+            None => spec_fibfib(x as nat) > u32::MAX,
+            Some(f) => f == spec_fibfib(x as nat)
+        },
 {
+    if x > 39 {
+        proof {
+            assert(spec_fibfib(40) > u32::MAX) by (compute_only);
+            lemma_fibfib_monotonic(40, x as nat);
+        }
+        return None;
+    }
     match (x) {
         0 => Some(0),
         1 => Some(0),
         2 => Some(1),
-        _ => fibfib(x - 1)?.checked_add(fibfib(x - 2)?)?.checked_add(fibfib(x - 3)?),
+        _ => {
+            proof {
+                // Prove that the recursive calls below succeed,
+                // and that the additions won't overflow
+                assert(spec_fibfib(39) < u32::MAX) by (compute_only);
+                lemma_fibfib_monotonic(x as nat, 39);
+                lemma_fibfib_monotonic((x - 1) as nat, 39);
+                lemma_fibfib_monotonic((x - 2) as nat, 39);
+                lemma_fibfib_monotonic((x - 3) as nat, 39);
+            }
+            Some(fibfib(x - 1)? + fibfib(x - 2)? + fibfib(x - 3)?)
+        }
     }
 }
 


### PR DESCRIPTION
The specs for tasks 8, 55a, 55b, 59, 60, 62, and 63 permitted trivial programs (e.g., that simply returned `None`).  The new versions are more restrictive, only allowing `None` to be returned under specific circumstances.