### PR TITLE
CI updates

### DIFF
--- a/.github/workflows/verus.yml
+++ b/.github/workflows/verus.yml
@@ -9,16 +9,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
-      - name: Install toolchain dependencies
-        shell: bash
-        run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --profile minimal --default-toolchain none -y
-          echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
-
       - name: Install Rust toolchain
         run: |
-          rustup update --no-self-update stable
-          rustup install 1.79.0-x86_64-unknown-linux-gnu
+          rustup install 1.82.0-x86_64-unknown-linux-gnu
 
       - name: Get the URL for the latest Verus release
         id: verus-release-info


### PR DESCRIPTION
Remove unnecessary steps, and update to Rust version needed for latest Verus.