### PR TITLE
Add solution to problem 133

### DIFF
--- a/tasks/human_eval_133.rs
+++ b/tasks/human_eval_133.rs
@@ -6,9 +6,8 @@ HumanEval/133
 ### VERUS BEGIN
 */
 use std::mem::take;
-use vstd::{arithmetic::overflow::CheckedU64, invariant, prelude::*};
 use vstd::arithmetic::mul::lemma_mul_cancels_negatives;
-
+use vstd::{arithmetic::overflow::CheckedU64, invariant, prelude::*};
 
 verus! {
 
@@ -75,9 +74,9 @@ fn sum_squares(v: Vec<i32>) -> (out: Option<u64>)
                 assert(val < 0);
                 let v1: int = ((-(val as i64)) as u64) as int;
                 let vx = v1;
-                assert((v1 * v1) >= 0); // Tentative to trigger lemma automatically did not worked
-                assert((v1 * v1) == (-v1) * (-v1) ) by {
-                    lemma_mul_cancels_negatives(v1,v1);
+                assert((v1 * v1) >= 0);  // Tentative to trigger lemma automatically did not worked
+                assert((v1 * v1) == (-v1) * (-v1)) by {
+                    lemma_mul_cancels_negatives(v1, v1);
                 };
             }
         }

--- a/tasks/human_eval_133.rs
+++ b/tasks/human_eval_133.rs
@@ -5,11 +5,104 @@ HumanEval/133
 /*
 ### VERUS BEGIN
 */
-use vstd::prelude::*;
+use std::mem::take;
+use vstd::{arithmetic::overflow::CheckedU64, invariant, prelude::*};
 
 verus! {
 
-// TODO: Put your solution (the specification, implementation, and proof) to the task here
+spec fn sum_squares_spec(arr: Seq<int>) -> int
+    decreases arr.len(),
+{
+    if (arr.len() == 0) {
+        0
+    } else {
+        (arr[0] * arr[0]) + sum_squares_spec(arr.drop_first())
+    }
+}
+
+proof fn lemma_sum_squares_spec_concat(a1: Seq<int>, a2: Seq<int>)
+    ensures
+        sum_squares_spec(a1 + a2) == sum_squares_spec(a1) + sum_squares_spec(a2),
+    decreases a1.len(),
+{
+    if (a1.len() == 0) {
+        assert(sum_squares_spec(a1 + a2) == sum_squares_spec(a1) + sum_squares_spec(a2));
+    } else {
+        assert((a1 + a2).drop_first() == a1.drop_first() + a2);
+        lemma_sum_squares_spec_concat(a1.drop_first(), a2);
+    }
+}
+
+fn sum_squares(v: Vec<i32>) -> (out: Option<u64>)
+    ensures
+        ({
+            let expected_sum = sum_squares_spec(v@.map_values(|x: i32| x as int));
+            match out {
+                Some(val) => val as int == expected_sum && expected_sum <= u64::MAX as int,
+                None => expected_sum > u64::MAX as int,
+            }
+        }),
+{
+    let mut s: CheckedU64 = CheckedU64::new(0);
+    let mut sq: CheckedU64 = CheckedU64::new(1);
+    for i in 0..v.len()
+        invariant
+            sq@ as int == 1,
+            s@ as int == sum_squares_spec(v@.take(i as int).map_values(|x: i32| x as int)),
+    {
+        let vi: u64 = if v[i] >= 0 {
+            v[i] as u64
+        } else {
+            (-(v[i] as i64)) as u64
+        };
+
+        let stemp = sq.mul_value(vi);
+        let stemp = stemp.mul_value(vi);
+        s = s.add_checked(&stemp);
+
+        assert(s@ as int == sum_squares_spec(v@.take((i + 1) as int).map_values(|x: i32| x as int)))
+            by {
+            let prev_slice = v@.take(i as int).map_values(|x: i32| x as int);
+            let cur_slice = v@.take((i + 1) as int).map_values(|x: i32| x as int);
+            let singleton_vi_seq = seq![cur_slice[i as int]];
+            assert(prev_slice + singleton_vi_seq =~= cur_slice);
+            lemma_sum_squares_spec_concat(prev_slice, singleton_vi_seq);
+            reveal_with_fuel(sum_squares_spec, 2);
+            if (v[i as int] < 0) {
+                let val: int = v[i as int] as int;
+                assert(val < 0);
+                let v1: int = ((-(val as i64)) as u64) as int;
+                assert(v1 == -(val));
+                assert(v1 * v1 == val * val) by (nonlinear_arith)
+                    requires
+                        v1 == -(val),
+                {}
+            }
+        }
+    };
+    assert(v@.take(v.len() as int) == v@);
+    return s.to_option();
+}
+
+fn static_checks() {
+    let v = vec![2,3,-1,5];
+    let r = sum_squares(v);
+
+    assert(r.unwrap() == 39) by {
+        let s: Seq<int> = seq![2, 3, -1, 5];
+        assert(v@.map_values(|x: i32| x as int) == s);
+        let s_res = sum_squares_spec(s);
+        assert(s_res == 39) by {
+            reveal_with_fuel(sum_squares_spec, 5);
+            assert(s[0] * s[0] == 4);
+            assert(s[1] * s[1] == 9);
+            assert(s[2] * s[2] == 1);
+            assert(s[3] * s[3] == 25);
+        }
+        let a = r.unwrap();
+        assert(a == 39);
+    };
+}
 
 } // verus!
 fn main() {}

--- a/tasks/human_eval_133.rs
+++ b/tasks/human_eval_133.rs
@@ -63,22 +63,14 @@ fn sum_squares(v: Vec<i32>) -> (out: Option<u64>)
 
         assert(s@ as int == sum_squares_spec(v@.take((i + 1) as int).map_values(|x: i32| x as int)))
             by {
+            broadcast use lemma_mul_cancels_negatives;
+
             let prev_slice = v@.take(i as int).map_values(|x: i32| x as int);
             let cur_slice = v@.take((i + 1) as int).map_values(|x: i32| x as int);
             let singleton_vi_seq = seq![cur_slice[i as int]];
             assert(prev_slice + singleton_vi_seq =~= cur_slice);
             lemma_sum_squares_spec_concat(prev_slice, singleton_vi_seq);
             reveal_with_fuel(sum_squares_spec, 2);
-            if (v[i as int] < 0) {
-                let val: int = v[i as int] as int;
-                assert(val < 0);
-                let v1: int = ((-(val as i64)) as u64) as int;
-                let vx = v1;
-                assert((v1 * v1) >= 0);  // Tentative to trigger lemma automatically did not worked
-                assert((v1 * v1) == (-v1) * (-v1)) by {
-                    lemma_mul_cancels_negatives(v1, v1);
-                };
-            }
         }
     };
     assert(v@.take(v.len() as int) == v@);

--- a/tasks/human_eval_133.rs
+++ b/tasks/human_eval_133.rs
@@ -7,6 +7,8 @@ HumanEval/133
 */
 use std::mem::take;
 use vstd::{arithmetic::overflow::CheckedU64, invariant, prelude::*};
+use vstd::arithmetic::mul::lemma_mul_cancels_negatives;
+
 
 verus! {
 
@@ -72,11 +74,11 @@ fn sum_squares(v: Vec<i32>) -> (out: Option<u64>)
                 let val: int = v[i as int] as int;
                 assert(val < 0);
                 let v1: int = ((-(val as i64)) as u64) as int;
-                assert(v1 == -(val));
-                assert(v1 * v1 == val * val) by (nonlinear_arith)
-                    requires
-                        v1 == -(val),
-                {}
+                let vx = v1;
+                assert((v1 * v1) >= 0); // Tentative to trigger lemma automatically did not worked
+                assert((v1 * v1) == (-v1) * (-v1) ) by {
+                    lemma_mul_cancels_negatives(v1,v1);
+                };
             }
         }
     };


### PR DESCRIPTION
The solution to problem (133) is essentially the same as that for problem 151. 

Limitations regarding Python version:
- The Python one is intended to work for (floats, reals), but as floats are not supported at the moment, the best that can be done is to use int.


I had some difficulty in proving a*a = (-a)*(-a) , I manage to do it like so:

```verus
                let val: int = v[i as int] as int;
                assert(val < 0);
                let v1: int = ((-(val as i64)) as u64) as int;
                assert(v1 == -(val));
                assert(v1 * v1 == val * val) by (nonlinear_arith)
                    requires
                        v1 == -(val),
                {}
```
It is unclear to me if that is the better approach




