### PR TITLE
Add solution to problem 10

### DIFF
--- a/tasks/human_eval_010.rs
+++ b/tasks/human_eval_010.rs
@@ -6,30 +6,10 @@ HumanEval/10
 ### VERUS BEGIN
 */
 use vstd::prelude::*;
+use vstd::slice::slice_subrange;
 
 verus! {
-
 // TODO: Put your solution (the specification, implementation, and proof) to the task here
-
-fn reverse(string: &[char]) -> (result: Vec<char>)
-    ensures
-        result.len() == string.len(),
-        forall |i: int| 0 <= i < string.len() ==> result[i] == string[string.len() - 1 - i],
-{
-    let mut reversed = Vec::new();
-    let mut i = string.len();
-    while i > 0
-        invariant
-            0 <= i <= string.len(),
-            reversed.len() == string.len() - i,
-            forall |j: int| 0 <= j < reversed.len() ==> reversed[j] == string[string.len() - 1 - j],
-        decreases i,
-    {
-        i -= 1;
-        reversed.push(string[i].clone());
-    }
-    reversed
-}
 
 spec fn spec_is_palindrome(string: Seq<char>) -> bool
 {
@@ -52,21 +32,11 @@ fn is_palindrome(string: &[char]) -> (result: bool)
         if string[i] != string[len - 1 - i] {
             return false;
         }
-        assert (string[i as int] == string[len - 1 - i]);
         i += 1;
     }
-
-    assert (forall |j: int| 0 <= j < len ==> #[trigger] string[j] == string[len - 1 - j]);
-    assert (forall |j: int| 0 <= j < len ==> #[trigger] string@[j] == string@[len - 1 - j]);
-    assert (forall |j: int| 0 <= j < len ==> #[trigger] string@[len - 1 - j] == string@.reverse()[j]);
-    assert (forall |j: int| 0 <= j < len ==> #[trigger] string@[j] == string@.reverse()[j]);
     assert (string@ =~= string@.reverse());
-    assert (spec_is_palindrome(string@));
-
     true
 }
-
-use vstd::slice::slice_subrange;
 
 proof fn palidrome_sandwich(a: Seq<char>, b: Seq<char>)
     requires
@@ -74,11 +44,6 @@ proof fn palidrome_sandwich(a: Seq<char>, b: Seq<char>)
     ensures
         spec_is_palindrome((a + b) + a.reverse()),
 {
-    assert (b == b.reverse());
-    assert (((a + b) + a.reverse()).reverse() == a.reverse().reverse() + (a + b).reverse());
-    assert (a.reverse().reverse() == a);
-    assert ((a + b).reverse() == b.reverse() + a.reverse());
-    assert ((a + b).reverse() == b + a.reverse());
     assert (((a + b) + a.reverse()).reverse() == a + b + a.reverse());
 }
 
@@ -89,9 +54,27 @@ proof fn palidrome_sandwich_reverse(a: Seq<char>, i: int)
     ensures
         spec_is_palindrome(a.subrange(i, a.len() - i)),
 {
-    assert forall |j: int| 0 <= j < a.len() - i - i implies a.subrange(i, a.len() - i)[j] == #[trigger] a.subrange(i, a.len() - i).reverse()[j] by {
-    }
     assert (a.subrange(i, a.len() - i) =~= a.subrange(i, a.len() - i).reverse());
+}
+
+fn reverse(string: &[char]) -> (result: Vec<char>)
+    ensures
+        result.len() == string.len(),
+        forall |i: int| 0 <= i < string.len() ==> result[i] == string[string.len() - 1 - i],
+{
+    let mut reversed = Vec::new();
+    let mut i = string.len();
+    while i > 0
+        invariant
+            0 <= i <= string.len(),
+            reversed.len() == string.len() - i,
+            forall |j: int| 0 <= j < reversed.len() ==> reversed[j] == string[string.len() - 1 - j],
+        decreases i,
+    {
+        i -= 1;
+        reversed.push(string[i].clone());
+    }
+    reversed
 }
 
 fn make_palindrome(string: Vec<char>) -> (result: Vec<char>)
@@ -115,38 +98,23 @@ fn make_palindrome(string: Vec<char>) -> (result: Vec<char>)
     }
 
     if !(beginning_of_suffix < len) {
-        assert (beginning_of_suffix == len);
         assert (string@.subrange(len as int, len as int) =~= Seq::<char>::empty());
     }
-    assert (spec_is_palindrome(string@.subrange(beginning_of_suffix as int, len as int)));
     let mut ret = string.clone();
     let mut app = reverse(slice_subrange(&string, 0, beginning_of_suffix));
     ret.append(&mut app);
 
-    assert (ret@ == string@ + string@.subrange(0, beginning_of_suffix as int).reverse());
-    assert (string@ == string@.subrange(0, beginning_of_suffix as int) + string@.subrange(beginning_of_suffix as int, len as int));
     assert (ret@ == (string@.subrange(0, beginning_of_suffix as int) + string@.subrange(beginning_of_suffix as int, len as int)) + string@.subrange(0, beginning_of_suffix as int).reverse());
     proof {
         palidrome_sandwich(string@.subrange(0, beginning_of_suffix as int), string@.subrange(beginning_of_suffix as int, len as int));
     }
-    assert (spec_is_palindrome(ret@));
-    assert (ret.len() == len + beginning_of_suffix);
-    assert (ret.len() <= len + len);
-
     assert forall |s: Seq<char>| #![auto] spec_is_palindrome(s) && s.len() >= len as int && s.subrange(0, string@.len() as int) == string@ implies ret@.len() <= s.len() by {
-        assert (spec_is_palindrome(s) && s.len() >= len as int && s.subrange(0, string@.len() as int) == string@);
         if (ret@.len() > s.len()) {
             palidrome_sandwich_reverse(s, s.len() - len);
-            assert (spec_is_palindrome(s.subrange(s.len() - len, len as int)));
-            assert (s.subrange(0, string@.len() as int) == string@);
             assert (s.subrange(s.len() - len, len as int) == s.subrange(0, string@.len() as int).subrange(s.len() - len, len as int));
-            assert (spec_is_palindrome(string@.subrange(s.len() - len, len as int)));
-            assert (s.len() - len < beginning_of_suffix);
-            assert (!spec_is_palindrome(string@.subrange(s.len() - len, len as int)));
-            assert (false);
         }
     }
-    return ret;
+    ret
 }
 } // verus!
 

--- a/tasks/human_eval_010.rs
+++ b/tasks/human_eval_010.rs
@@ -11,12 +11,159 @@ verus! {
 
 // TODO: Put your solution (the specification, implementation, and proof) to the task here
 
+fn reverse(string: &[char]) -> (result: Vec<char>)
+    ensures
+        result.len() == string.len(),
+        forall |i: int| 0 <= i < string.len() ==> result[i] == string[string.len() - 1 - i],
+{
+    let mut reversed = Vec::new();
+    let mut i = string.len();
+    while i > 0
+        invariant
+            0 <= i <= string.len(),
+            reversed.len() == string.len() - i,
+            forall |j: int| 0 <= j < reversed.len() ==> reversed[j] == string[string.len() - 1 - j],
+        decreases i,
+    {
+        i -= 1;
+        reversed.push(string[i].clone());
+    }
+    reversed
+}
+
+spec fn spec_is_palindrome(string: Seq<char>) -> bool
+{
+    string == string.reverse()
+}
+
+fn is_palindrome(string: &[char]) -> (result: bool)
+    ensures
+        result <==> spec_is_palindrome(string@),
+{
+    let len: usize = string.len();
+    let mut i: usize = 0;
+    while i < len
+        invariant
+            len == string.len(),
+            0 <= i <= len,
+            forall |j: int| 0 <= j < i ==> #[trigger] string[j] == string[len - 1 - j],
+        decreases len - i,
+    {
+        if string[i] != string[len - 1 - i] {
+            return false;
+        }
+        assert (string[i as int] == string[len - 1 - i]);
+        i += 1;
+    }
+
+    assert (forall |j: int| 0 <= j < len ==> #[trigger] string[j] == string[len - 1 - j]);
+    assert (forall |j: int| 0 <= j < len ==> #[trigger] string@[j] == string@[len - 1 - j]);
+    assert (forall |j: int| 0 <= j < len ==> #[trigger] string@[len - 1 - j] == string@.reverse()[j]);
+    assert (forall |j: int| 0 <= j < len ==> #[trigger] string@[j] == string@.reverse()[j]);
+    assert (string@ =~= string@.reverse());
+    assert (spec_is_palindrome(string@));
+
+    true
+}
+
+use vstd::slice::slice_subrange;
+
+proof fn palidrome_sandwich(a: Seq<char>, b: Seq<char>)
+    requires
+        spec_is_palindrome(b),
+    ensures
+        spec_is_palindrome((a + b) + a.reverse()),
+{
+    assert (b == b.reverse());
+    assert (((a + b) + a.reverse()).reverse() == a.reverse().reverse() + (a + b).reverse());
+    assert (a.reverse().reverse() == a);
+    assert ((a + b).reverse() == b.reverse() + a.reverse());
+    assert ((a + b).reverse() == b + a.reverse());
+    assert (((a + b) + a.reverse()).reverse() == a + b + a.reverse());
+}
+
+proof fn palidrome_sandwich_reverse(a: Seq<char>, i: int)
+    requires
+        spec_is_palindrome(a),
+        0 <= i <= a.len() - i,
+    ensures
+        spec_is_palindrome(a.subrange(i, a.len() - i)),
+{
+    assert forall |j: int| 0 <= j < a.len() - i - i implies a.subrange(i, a.len() - i)[j] == #[trigger] a.subrange(i, a.len() - i).reverse()[j] by {
+    }
+    assert (a.subrange(i, a.len() - i) =~= a.subrange(i, a.len() - i).reverse());
+}
+
+fn make_palindrome(string: Vec<char>) -> (result: Vec<char>)
+    ensures
+        result.len() >= string.len(),
+        result@.subrange(0, string@.len() as int) == string@,
+        spec_is_palindrome(result@),
+        forall |s: Seq<char>| #![auto] spec_is_palindrome(s) && s.len() >= string.len() as int && s.subrange(0, string@.len() as int) == string@ ==> result@.len() <= s.len(),
+{
+    let len = string.len();
+    let mut beginning_of_suffix = 0;
+
+    while beginning_of_suffix < len && !is_palindrome(slice_subrange(string.as_slice(), beginning_of_suffix, len))
+        invariant
+            len == string.len(),
+            0 <= beginning_of_suffix <= len,
+            forall |bos: int| #![auto] 0 <= bos < beginning_of_suffix ==> !spec_is_palindrome(string@.subrange(bos, len as int)),
+        decreases len - beginning_of_suffix,
+    {
+        beginning_of_suffix += 1;
+    }
+
+    if !(beginning_of_suffix < len) {
+        assert (beginning_of_suffix == len);
+        assert (string@.subrange(len as int, len as int) =~= Seq::<char>::empty());
+    }
+    assert (spec_is_palindrome(string@.subrange(beginning_of_suffix as int, len as int)));
+    let mut ret = string.clone();
+    let mut app = reverse(slice_subrange(&string, 0, beginning_of_suffix));
+    ret.append(&mut app);
+
+    assert (ret@ == string@ + string@.subrange(0, beginning_of_suffix as int).reverse());
+    assert (string@ == string@.subrange(0, beginning_of_suffix as int) + string@.subrange(beginning_of_suffix as int, len as int));
+    assert (ret@ == (string@.subrange(0, beginning_of_suffix as int) + string@.subrange(beginning_of_suffix as int, len as int)) + string@.subrange(0, beginning_of_suffix as int).reverse());
+    proof {
+        palidrome_sandwich(string@.subrange(0, beginning_of_suffix as int), string@.subrange(beginning_of_suffix as int, len as int));
+    }
+    assert (spec_is_palindrome(ret@));
+    assert (ret.len() == len + beginning_of_suffix);
+    assert (ret.len() <= len + len);
+
+    assert forall |s: Seq<char>| #![auto] spec_is_palindrome(s) && s.len() >= len as int && s.subrange(0, string@.len() as int) == string@ implies ret@.len() <= s.len() by {
+        assert (spec_is_palindrome(s) && s.len() >= len as int && s.subrange(0, string@.len() as int) == string@);
+        if (ret@.len() > s.len()) {
+            palidrome_sandwich_reverse(s, s.len() - len);
+            assert (spec_is_palindrome(s.subrange(s.len() - len, len as int)));
+            assert (s.subrange(0, string@.len() as int) == string@);
+            assert (s.subrange(s.len() - len, len as int) == s.subrange(0, string@.len() as int).subrange(s.len() - len, len as int));
+            assert (spec_is_palindrome(string@.subrange(s.len() - len, len as int)));
+            assert (s.len() - len < beginning_of_suffix);
+            assert (!spec_is_palindrome(string@.subrange(s.len() - len, len as int)));
+            assert (false);
+        }
+    }
+    return ret;
+}
 } // verus!
-fn main() {}
 
 /*
 ### VERUS END
 */
+
+pub fn runtime_test() {
+    assert_eq!(make_palindrome(vec!['c','a','t']), vec!['c','a','t','a','c']);
+    assert_eq!(make_palindrome(vec!['c','a','t','a']), vec!['c','a','t','a','c']);
+    assert_eq!(make_palindrome(vec![]), vec![]);
+    assert_eq!(make_palindrome(vec!['x']), vec!['x']);
+    assert_eq!(make_palindrome(vec!['x','y','z']), vec!['x','y','z','y','x']);
+    assert_eq!(make_palindrome(vec!['x','y','x']), vec!['x','y','x']);
+    assert_eq!(make_palindrome(vec!['j','e','r','r','y']), vec!['j','e','r','r','y','r','r','e','j']);
+    println!("All tests passed!");
+}
 
 /*
 ### PROMPT

--- a/tasks/human_eval_010.rs
+++ b/tasks/human_eval_010.rs
@@ -112,6 +112,8 @@ fn make_palindrome(string: Vec<char>) -> (result: Vec<char>)
         if (ret@.len() > s.len()) {
             palidrome_sandwich_reverse(s, s.len() - len);
             assert (s.subrange(s.len() - len, len as int) == s.subrange(0, string@.len() as int).subrange(s.len() - len, len as int));
+            // contradicts with the instantialization of (0 <= bos < beginning_of_suffix ==> !spec_is_palindrome(string@.subrange(bos, len as int)))
+            // by taking bos = s.len() - len
         }
     }
     ret

--- a/tasks/human_eval_010.rs
+++ b/tasks/human_eval_010.rs
@@ -9,10 +9,8 @@ use vstd::prelude::*;
 use vstd::slice::slice_subrange;
 
 verus! {
-// TODO: Put your solution (the specification, implementation, and proof) to the task here
 
-spec fn spec_is_palindrome(string: Seq<char>) -> bool
-{
+spec fn spec_is_palindrome(string: Seq<char>) -> bool {
     string == string.reverse()
 }
 
@@ -26,7 +24,7 @@ fn is_palindrome(string: &[char]) -> (result: bool)
         invariant
             len == string.len(),
             0 <= i <= len,
-            forall |j: int| 0 <= j < i ==> #[trigger] string[j] == string[len - 1 - j],
+            forall|j: int| 0 <= j < i ==> #[trigger] string[j] == string[len - 1 - j],
         decreases len - i,
     {
         if string[i] != string[len - 1 - i] {
@@ -34,7 +32,7 @@ fn is_palindrome(string: &[char]) -> (result: bool)
         }
         i += 1;
     }
-    assert (string@ =~= string@.reverse());
+    assert(string@ =~= string@.reverse());
     true
 }
 
@@ -44,7 +42,7 @@ proof fn palidrome_sandwich(a: Seq<char>, b: Seq<char>)
     ensures
         spec_is_palindrome((a + b) + a.reverse()),
 {
-    assert (((a + b) + a.reverse()).reverse() == a + b + a.reverse());
+    assert(((a + b) + a.reverse()).reverse() == a + b + a.reverse());
 }
 
 proof fn palidrome_sandwich_reverse(a: Seq<char>, i: int)
@@ -54,13 +52,13 @@ proof fn palidrome_sandwich_reverse(a: Seq<char>, i: int)
     ensures
         spec_is_palindrome(a.subrange(i, a.len() - i)),
 {
-    assert (a.subrange(i, a.len() - i) =~= a.subrange(i, a.len() - i).reverse());
+    assert(a.subrange(i, a.len() - i) =~= a.subrange(i, a.len() - i).reverse());
 }
 
 fn reverse(string: &[char]) -> (result: Vec<char>)
     ensures
         result.len() == string.len(),
-        forall |i: int| 0 <= i < string.len() ==> result[i] == string[string.len() - 1 - i],
+        forall|i: int| 0 <= i < string.len() ==> result[i] == string[string.len() - 1 - i],
 {
     let mut reversed = Vec::new();
     let mut i = string.len();
@@ -68,7 +66,7 @@ fn reverse(string: &[char]) -> (result: Vec<char>)
         invariant
             0 <= i <= string.len(),
             reversed.len() == string.len() - i,
-            forall |j: int| 0 <= j < reversed.len() ==> reversed[j] == string[string.len() - 1 - j],
+            forall|j: int| 0 <= j < reversed.len() ==> reversed[j] == string[string.len() - 1 - j],
         decreases i,
     {
         i -= 1;
@@ -82,56 +80,90 @@ fn make_palindrome(string: Vec<char>) -> (result: Vec<char>)
         result.len() >= string.len(),
         result@.subrange(0, string@.len() as int) == string@,
         spec_is_palindrome(result@),
-        forall |s: Seq<char>| #![auto] spec_is_palindrome(s) && s.len() >= string.len() as int && s.subrange(0, string@.len() as int) == string@ ==> result@.len() <= s.len(),
+        forall|s: Seq<char>|
+            #![auto]
+            spec_is_palindrome(s) && s.len() >= string.len() as int && s.subrange(
+                0,
+                string@.len() as int,
+            ) == string@ ==> result@.len() <= s.len(),
 {
     let len = string.len();
     let mut beginning_of_suffix = 0;
 
-    while beginning_of_suffix < len && !is_palindrome(slice_subrange(string.as_slice(), beginning_of_suffix, len))
+    while beginning_of_suffix < len && !is_palindrome(
+        slice_subrange(string.as_slice(), beginning_of_suffix, len),
+    )
         invariant
             len == string.len(),
             0 <= beginning_of_suffix <= len,
-            forall |bos: int| #![auto] 0 <= bos < beginning_of_suffix ==> !spec_is_palindrome(string@.subrange(bos, len as int)),
+            forall|bos: int|
+                #![auto]
+                0 <= bos < beginning_of_suffix ==> !spec_is_palindrome(
+                    string@.subrange(bos, len as int),
+                ),
         decreases len - beginning_of_suffix,
     {
         beginning_of_suffix += 1;
     }
 
     if !(beginning_of_suffix < len) {
-        assert (string@.subrange(len as int, len as int) =~= Seq::<char>::empty());
+        assert(string@.subrange(len as int, len as int) =~= Seq::<char>::empty());
     }
     let mut ret = string.clone();
     let mut app = reverse(slice_subrange(&string, 0, beginning_of_suffix));
     ret.append(&mut app);
 
-    assert (ret@ == (string@.subrange(0, beginning_of_suffix as int) + string@.subrange(beginning_of_suffix as int, len as int)) + string@.subrange(0, beginning_of_suffix as int).reverse());
+    assert(ret@ == (string@.subrange(0, beginning_of_suffix as int) + string@.subrange(
+        beginning_of_suffix as int,
+        len as int,
+    )) + string@.subrange(0, beginning_of_suffix as int).reverse());
     proof {
-        palidrome_sandwich(string@.subrange(0, beginning_of_suffix as int), string@.subrange(beginning_of_suffix as int, len as int));
+        palidrome_sandwich(
+            string@.subrange(0, beginning_of_suffix as int),
+            string@.subrange(beginning_of_suffix as int, len as int),
+        );
     }
-    assert forall |s: Seq<char>| #![auto] spec_is_palindrome(s) && s.len() >= len as int && s.subrange(0, string@.len() as int) == string@ implies ret@.len() <= s.len() by {
+    assert forall|s: Seq<char>|
+        #![auto]
+        spec_is_palindrome(s) && s.len() >= len as int && s.subrange(0, string@.len() as int)
+            == string@ implies ret@.len() <= s.len() by {
         if (ret@.len() > s.len()) {
             palidrome_sandwich_reverse(s, s.len() - len);
-            assert (s.subrange(s.len() - len, len as int) == s.subrange(0, string@.len() as int).subrange(s.len() - len, len as int));
+            assert(s.subrange(s.len() - len, len as int) == s.subrange(
+                0,
+                string@.len() as int,
+            ).subrange(s.len() - len, len as int));
             // contradicts with the instantialization of (0 <= bos < beginning_of_suffix ==> !spec_is_palindrome(string@.subrange(bos, len as int)))
             // by taking bos = s.len() - len
         }
     }
     ret
 }
-} // verus!
 
+} // verus!
 /*
 ### VERUS END
 */
-
-pub fn runtime_test() {
-    assert_eq!(make_palindrome(vec!['c','a','t']), vec!['c','a','t','a','c']);
-    assert_eq!(make_palindrome(vec!['c','a','t','a']), vec!['c','a','t','a','c']);
+pub fn main() {
+    assert_eq!(
+        make_palindrome(vec!['c', 'a', 't']),
+        vec!['c', 'a', 't', 'a', 'c']
+    );
+    assert_eq!(
+        make_palindrome(vec!['c', 'a', 't', 'a']),
+        vec!['c', 'a', 't', 'a', 'c']
+    );
     assert_eq!(make_palindrome(vec![]), vec![]);
     assert_eq!(make_palindrome(vec!['x']), vec!['x']);
-    assert_eq!(make_palindrome(vec!['x','y','z']), vec!['x','y','z','y','x']);
-    assert_eq!(make_palindrome(vec!['x','y','x']), vec!['x','y','x']);
-    assert_eq!(make_palindrome(vec!['j','e','r','r','y']), vec!['j','e','r','r','y','r','r','e','j']);
+    assert_eq!(
+        make_palindrome(vec!['x', 'y', 'z']),
+        vec!['x', 'y', 'z', 'y', 'x']
+    );
+    assert_eq!(make_palindrome(vec!['x', 'y', 'x']), vec!['x', 'y', 'x']);
+    assert_eq!(
+        make_palindrome(vec!['j', 'e', 'r', 'r', 'y']),
+        vec!['j', 'e', 'r', 'r', 'y', 'r', 'r', 'e', 'j']
+    );
     println!("All tests passed!");
 }
 


### PR DESCRIPTION
I noticed that there is some inconsistency regarding how to represent `str` type in python in Rust:
- 001, 011, 015 uses `&[char]` or `Vec<char>`
- 012 and 014 uses `Vec<u8>`
- 006 uses `&str`

I think the first one is better and I choose it. I believe the second is the same to the first one modulo a generic data type. And the code of 006 has performance issue because it calls .chars().nth(i) for each i.